### PR TITLE
Fix `~"` syntax

### DIFF
--- a/Erlang.plist
+++ b/Erlang.plist
@@ -2536,7 +2536,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>~.?</string>
+					<string>~[^"]?</string>
 					<key>name</key>
 					<string>invalid.illegal.string.erlang</string>
 				</dict>


### PR DESCRIPTION
If a string ends with a `~"` we cannot know if it is a valid control character or not, so we should not show it as an error.