### PR TITLE
Syntax updates from pgourlain/vscode_erlang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Erlang.yaml

--- a/Erlang.plist
+++ b/Erlang.plist
@@ -7,7 +7,10 @@
 	<key>fileTypes</key>
 	<array>
 		<string>erl</string>
+		<string>escript</string>
 		<string>hrl</string>
+		<string>xrl</string>
+		<string>yrl</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~E</string>
@@ -98,7 +101,7 @@
 								</dict>
 							</dict>
 							<key>match</key>
-							<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3})</string>
+							<string>(\\)([bdefnrstv\\'"]|(\^)[@-_a-z]|[0-7]{1,3}|x[\da-fA-F]{2})</string>
 							<key>name</key>
 							<string>constant.other.symbol.escape.erlang</string>
 						</dict>
@@ -240,7 +243,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\$)((\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3}))</string>
+					<string>(\$)((\\)([bdefnrstv\\'"]|(\^)[@-_a-z]|[0-7]{1,3}|x[\da-fA-F]{2}))</string>
 					<key>name</key>
 					<string>constant.character.erlang</string>
 				</dict>
@@ -260,7 +263,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\$)\S</string>
+					<string>(\$)[ \S]</string>
 					<key>name</key>
 					<string>constant.character.erlang</string>
 				</dict>
@@ -312,7 +315,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>^\s*+(-)\s*+(define)\s*+(\()\s*+([a-zA-Z\d@_]++)\s*+(,)</string>
+					<string>^\s*+(-)\s*+(define)\s*+(\()\s*+([a-zA-Z\d@_]++)\s*+</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -334,11 +337,6 @@
 						<dict>
 							<key>name</key>
 							<string>entity.name.function.macro.definition.erlang</string>
-						</dict>
-						<key>5</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.parameters.erlang</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -568,6 +566,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#language-constant</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#function-call</string>
 				</dict>
 				<dict>
@@ -729,6 +731,54 @@
 							<key>name</key>
 							<string>keyword.control.fun.erlang</string>
 						</dict>
+						<key>10</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.function-arity.erlang</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.type.class.module.erlang</string>
+						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.erlang</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.module-function.erlang</string>
+						</dict>
+						<key>8</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.erlang</string>
+						</dict>
+						<key>9</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.erlang</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Implicit function expression with optional module qualifier when both module and function can be atom or variable</string>
+					<key>match</key>
+					<string>\b(fun)\s+((([a-z][a-zA-Z\d@_]*+)|(_[a-zA-Z\d@_]++|[A-Z][a-zA-Z\d@_]*+))\s*+(:)\s*+)?(([a-z][a-zA-Z\d@_]*+|'[^']*+')|(_[a-zA-Z\d@_]++|[A-Z][a-zA-Z\d@_]*+))\s*(/)</string>
+					<key>name</key>
+					<string>meta.expression.fun.implicit.erlang</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\b(fun)\s+(([a-z][a-zA-Z\d@_]*+)|(_[a-zA-Z\d@_]++|[A-Z][a-zA-Z\d@_]*+))\s*+(:)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.fun.erlang</string>
+						</dict>
 						<key>3</key>
 						<dict>
 							<key>name</key>
@@ -737,21 +787,104 @@
 						<key>4</key>
 						<dict>
 							<key>name</key>
-							<string>punctuation.separator.module-function.erlang</string>
+							<string>variable.other.erlang</string>
 						</dict>
 						<key>5</key>
 						<dict>
 							<key>name</key>
-							<string>entity.name.function.erlang</string>
+							<string>punctuation.separator.module-function.erlang</string>
 						</dict>
-						<key>6</key>
+					</dict>
+					<key>comment</key>
+					<string>Implicit function expression with module qualifier when module can be atom or variable and function can by anything</string>
+					<key>end</key>
+					<string>(/)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.separator.function-arity.erlang</string>
 						</dict>
 					</dict>
-					<key>match</key>
-					<string>\b(fun)\s+(([a-z][a-zA-Z\d@_]*+)\s*+(:)\s*+)?([a-z][a-zA-Z\d@_]*+)\s*(/)</string>
+					<key>name</key>
+					<string>meta.expression.fun.implicit.erlang</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#everything-else</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\b(fun)\s+(?!\()</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.fun.erlang</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Implicit function expression when both module and function can by anything</string>
+					<key>end</key>
+					<string>(/)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.separator.function-arity.erlang</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.expression.fun.implicit.erlang</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#everything-else</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\b(fun)\s*+(\()(?=(\s*+\())</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.erlang</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.parameters.begin.erlang</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Function type in type specification</string>
+					<key>end</key>
+					<string>(\))</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.parameters.end.erlang</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#everything-else</string>
+						</dict>
+					</array>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -764,6 +897,8 @@
 							<string>keyword.control.fun.erlang</string>
 						</dict>
 					</dict>
+					<key>comment</key>
+					<string>Explicit function expression</string>
 					<key>end</key>
 					<string>\b(end)\b</string>
 					<key>endCaptures</key>
@@ -980,7 +1115,7 @@
 		<key>function-call</key>
 		<dict>
 			<key>begin</key>
-			<string>(?=([a-z][a-zA-Z\d@_]*+|'[^']*+')\s*+(\(|:\s*+([a-z][a-zA-Z\d@_]*+|'[^']*+')\s*+\())</string>
+			<string>(?=([a-z][a-zA-Z\d@_]*+|'[^']*+'|_[a-zA-Z\d@_]++|[A-Z][a-zA-Z\d@_]*+)\s*+(\(|:\s*+([a-z][a-zA-Z\d@_]*+|'[^']*+'|_[a-zA-Z\d@_]++|[A-Z][a-zA-Z\d@_]*+)\s*+\())</string>
 			<key>end</key>
 			<string>(\))</string>
 			<key>endCaptures</key>
@@ -1039,25 +1174,35 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(([a-z][a-zA-Z\d@_]*+|'[^']*+')\s*+(:)\s*+)?([a-z][a-zA-Z\d@_]*+|'[^']*+')\s*+(\()</string>
+					<string>((([a-z][a-zA-Z\d@_]*+|'[^']*+')|(_[a-zA-Z\d@_]++|[A-Z][a-zA-Z\d@_]*+))\s*+(:)\s*+)?(([a-z][a-zA-Z\d@_]*+|'[^']*+')|(_[a-zA-Z\d@_]++|[A-Z][a-zA-Z\d@_]*+))\s*+(\()</string>
 					<key>beginCaptures</key>
 					<dict>
-						<key>2</key>
+						<key>3</key>
 						<dict>
 							<key>name</key>
 							<string>entity.name.type.class.module.erlang</string>
 						</dict>
-						<key>3</key>
+						<key>4</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.erlang</string>
+						</dict>
+						<key>5</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.separator.module-function.erlang</string>
 						</dict>
-						<key>4</key>
+						<key>7</key>
 						<dict>
 							<key>name</key>
 							<string>entity.name.function.erlang</string>
 						</dict>
-						<key>5</key>
+						<key>8</key>
+						<dict>
+							<key>name</key>
+							<string>variable.other.erlang</string>
+						</dict>
+						<key>9</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.parameters.begin.erlang</string>
@@ -1369,14 +1514,22 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?=\})</string>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.class.record.end.erlang</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>meta.structure.record.erlang</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(([a-z][a-zA-Z\d@_]*+|'[^']*+')|(_))\s*+(=|::)</string>
+					<string>(([a-z][a-zA-Z\d@_]*+|'[^']*+')|(_))</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>
@@ -1388,11 +1541,6 @@
 						<dict>
 							<key>name</key>
 							<string>variable.language.omitted.field.erlang</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.operator.assignment.erlang</string>
 						</dict>
 					</dict>
 					<key>end</key>
@@ -1412,23 +1560,6 @@
 							<string>#everything-else</string>
 						</dict>
 					</array>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>variable.other.field.erlang</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.class.record.erlang</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>([a-z][a-zA-Z\d@_]*+|'[^']*+')\s*+(,)?</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1478,11 +1609,21 @@
 						<key>5</key>
 						<dict>
 							<key>name</key>
+							<string>punctuation.separator.unit-specifiers.erlang</string>
+						</dict>
+						<key>6</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.integer.decimal.erlang</string>
+						</dict>
+						<key>7</key>
+						<dict>
+							<key>name</key>
 							<string>punctuation.separator.type-specifiers.erlang</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(integer|float|binary|bytes|bitstring|bits)|(signed|unsigned)|(big|little|native)|(unit)|(-)</string>
+					<string>(integer|float|binary|bytes|bitstring|bits|utf8|utf16|utf32)|(signed|unsigned)|(big|little|native)|(unit)(:)(\d++)|(-)</string>
 				</dict>
 			</array>
 		</dict>
@@ -1492,6 +1633,13 @@
 			<string>\b(after|begin|case|catch|cond|end|fun|if|let|of|query|try|receive|when)\b</string>
 			<key>name</key>
 			<string>keyword.control.erlang</string>
+		</dict>
+		<key>language-constant</key>
+		<dict>
+			<key>match</key>
+			<string>\b(false|true|undefined)\b</string>
+			<key>name</key>
+			<string>constant.language</string>
 		</dict>
 		<key>list</key>
 		<dict>
@@ -1751,7 +1899,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>2(#)[0-1]++</string>
+					<string>2(#)([0-1]++_)*[0-1]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.binary.erlang</string>
 				</dict>
@@ -1765,7 +1913,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>3(#)[0-2]++</string>
+					<string>3(#)([0-2]++_)*[0-2]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-3.erlang</string>
 				</dict>
@@ -1779,7 +1927,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>4(#)[0-3]++</string>
+					<string>4(#)([0-3]++_)*[0-3]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-4.erlang</string>
 				</dict>
@@ -1793,7 +1941,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>5(#)[0-4]++</string>
+					<string>5(#)([0-4]++_)*[0-4]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-5.erlang</string>
 				</dict>
@@ -1807,7 +1955,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>6(#)[0-5]++</string>
+					<string>6(#)([0-5]++_)*[0-5]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-6.erlang</string>
 				</dict>
@@ -1821,7 +1969,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>7(#)[0-6]++</string>
+					<string>7(#)([0-6]++_)*[0-6]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-7.erlang</string>
 				</dict>
@@ -1835,7 +1983,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>8(#)[0-7]++</string>
+					<string>8(#)([0-7]++_)*[0-7]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.octal.erlang</string>
 				</dict>
@@ -1849,7 +1997,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>9(#)[0-8]++</string>
+					<string>9(#)([0-8]++_)*[0-8]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-9.erlang</string>
 				</dict>
@@ -1863,7 +2011,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>10(#)\d++</string>
+					<string>10(#)(\d++_)*\d++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.decimal.erlang</string>
 				</dict>
@@ -1877,7 +2025,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>11(#)[\daA]++</string>
+					<string>11(#)([\daA]++_)*[\daA]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-11.erlang</string>
 				</dict>
@@ -1891,7 +2039,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>12(#)[\da-bA-B]++</string>
+					<string>12(#)([\da-bA-B]++_)*[\da-bA-B]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-12.erlang</string>
 				</dict>
@@ -1905,7 +2053,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>13(#)[\da-cA-C]++</string>
+					<string>13(#)([\da-cA-C]++_)*[\da-cA-C]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-13.erlang</string>
 				</dict>
@@ -1919,7 +2067,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>14(#)[\da-dA-D]++</string>
+					<string>14(#)([\da-dA-D]++_)*[\da-dA-D]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-14.erlang</string>
 				</dict>
@@ -1933,7 +2081,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>15(#)[\da-eA-E]++</string>
+					<string>15(#)([\da-eA-E]++_)*[\da-eA-E]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-15.erlang</string>
 				</dict>
@@ -1947,7 +2095,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>16(#)[0-9A-Fa-f]++</string>
+					<string>16(#)([\da-fA-F]++_)*[\da-fA-F]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.hexadecimal.erlang</string>
 				</dict>
@@ -1961,7 +2109,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>17(#)[\da-gA-G]++</string>
+					<string>17(#)([\da-gA-G]++_)*[\da-gA-G]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-17.erlang</string>
 				</dict>
@@ -1975,7 +2123,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>18(#)[\da-hA-H]++</string>
+					<string>18(#)([\da-hA-H]++_)*[\da-hA-H]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-18.erlang</string>
 				</dict>
@@ -1989,7 +2137,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>19(#)[\da-iA-I]++</string>
+					<string>19(#)([\da-iA-I]++_)*[\da-iA-I]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-19.erlang</string>
 				</dict>
@@ -2003,7 +2151,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>20(#)[\da-jA-J]++</string>
+					<string>20(#)([\da-jA-J]++_)*[\da-jA-J]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-20.erlang</string>
 				</dict>
@@ -2017,7 +2165,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>21(#)[\da-kA-K]++</string>
+					<string>21(#)([\da-kA-K]++_)*[\da-kA-K]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-21.erlang</string>
 				</dict>
@@ -2031,7 +2179,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>22(#)[\da-lA-L]++</string>
+					<string>22(#)([\da-lA-L]++_)*[\da-lA-L]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-22.erlang</string>
 				</dict>
@@ -2045,7 +2193,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>23(#)[\da-mA-M]++</string>
+					<string>23(#)([\da-mA-M]++_)*[\da-mA-M]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-23.erlang</string>
 				</dict>
@@ -2059,7 +2207,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>24(#)[\da-nA-N]++</string>
+					<string>24(#)([\da-nA-N]++_)*[\da-nA-N]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-24.erlang</string>
 				</dict>
@@ -2073,7 +2221,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>25(#)[\da-oA-O]++</string>
+					<string>25(#)([\da-oA-O]++_)*[\da-oA-O]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-25.erlang</string>
 				</dict>
@@ -2087,7 +2235,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>26(#)[\da-pA-P]++</string>
+					<string>26(#)([\da-pA-P]++_)*[\da-pA-P]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-26.erlang</string>
 				</dict>
@@ -2101,7 +2249,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>27(#)[\da-qA-Q]++</string>
+					<string>27(#)([\da-qA-Q]++_)*[\da-qA-Q]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-27.erlang</string>
 				</dict>
@@ -2115,7 +2263,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>28(#)[\da-rA-R]++</string>
+					<string>28(#)([\da-rA-R]++_)*[\da-rA-R]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-28.erlang</string>
 				</dict>
@@ -2129,7 +2277,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>29(#)[\da-sA-S]++</string>
+					<string>29(#)([\da-sA-S]++_)*[\da-sA-S]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-29.erlang</string>
 				</dict>
@@ -2143,7 +2291,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>30(#)[\da-tA-T]++</string>
+					<string>30(#)([\da-tA-T]++_)*[\da-tA-T]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-30.erlang</string>
 				</dict>
@@ -2157,7 +2305,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>31(#)[\da-uA-U]++</string>
+					<string>31(#)([\da-uA-U]++_)*[\da-uA-U]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-31.erlang</string>
 				</dict>
@@ -2171,7 +2319,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>32(#)[\da-vA-V]++</string>
+					<string>32(#)([\da-vA-V]++_)*[\da-vA-V]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-32.erlang</string>
 				</dict>
@@ -2185,7 +2333,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>33(#)[\da-wA-W]++</string>
+					<string>33(#)([\da-wA-W]++_)*[\da-wA-W]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-33.erlang</string>
 				</dict>
@@ -2199,7 +2347,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>34(#)[\da-xA-X]++</string>
+					<string>34(#)([\da-xA-X]++_)*[\da-xA-X]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-34.erlang</string>
 				</dict>
@@ -2213,7 +2361,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>35(#)[\da-yA-Y]++</string>
+					<string>35(#)([\da-yA-Y]++_)*[\da-yA-Y]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-35.erlang</string>
 				</dict>
@@ -2227,19 +2375,19 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>36(#)[\da-zA-Z]++</string>
+					<string>36(#)([\da-zA-Z]++_)*[\da-zA-Z]++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.base-36.erlang</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\d++#[\da-zA-Z]++</string>
+					<string>\d++#([\da-zA-Z]++_)*[\da-zA-Z]++</string>
 					<key>name</key>
 					<string>invalid.illegal.integer.erlang</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\d++</string>
+					<string>(\d++_)*\d++</string>
 					<key>name</key>
 					<string>constant.numeric.integer.decimal.erlang</string>
 				</dict>
@@ -2310,25 +2458,15 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>((\}))\s*+(\))\s*+(\.)</string>
+			<string>(\))\s*+(\.)</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>meta.structure.record.erlang</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.class.record.end.erlang</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
 					<string>punctuation.definition.parameters.end.erlang</string>
 				</dict>
-				<key>4</key>
+				<key>2</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.section.directive.end.erlang</string>
@@ -2341,6 +2479,10 @@
 				<dict>
 					<key>include</key>
 					<string>#internal-record-body</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
 				</dict>
 			</array>
 		</dict>
@@ -2394,20 +2536,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>((\}))</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>meta.structure.record.erlang</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.class.record.end.erlang</string>
-						</dict>
-					</dict>
+					<string>(?&lt;=\})</string>
 					<key>name</key>
 					<string>meta.record-usage.erlang</string>
 					<key>patterns</key>
@@ -2461,7 +2590,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\\)([bdefnrstv\\'"]|(\^)[@-_]|[0-7]{1,3})</string>
+					<string>(\\)([bdefnrstv\\'"]|(\^)[@-_a-z]|[0-7]{1,3}|x[\da-fA-F]{2})</string>
 					<key>name</key>
 					<string>constant.character.escape.erlang</string>
 				</dict>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Erlang Grammar
 
-TextMate grammar (also used by VS Code) for the Erlang programming language.
+TextMate grammar (also used by Visual Studio Code) for the Erlang programming
+language.
 
 ## Credits
 
@@ -10,7 +11,7 @@ https://github.com/textmate/erlang.tmbundle
 
 The original license stated:
 
-```
+```text
 Permission to copy, use, modify, sell and distribute this
 software is granted. This software is provided "as is" without
 express or implied warranty, and with no claim as to its
@@ -27,3 +28,43 @@ The reason of the fork is twofold:
 
 The current repository is licensed under the Apache License 2.0.
 Please refer to the `LICENSE` file for details.
+
+## Lazy Guide
+
+According Visual Studio Code Syntax Highlight Guide:
+> As a grammar grows more complex, it can become difficult to understand and
+> maintain it as json. If you find yourself writing complex regular expressions
+> or needing to add comments to explain aspects of the grammar, consider using
+> yaml to define your grammar instead.
+>
+> Yaml grammars have the exact same structure as a json based grammar but allow
+> you to use yaml's more concise syntax, along with features such as multi-line
+> strings and comments.
+>
+> VS Code can only load json _[or plist]_ grammars, so yaml based grammars must
+> be converted to json _[or plist]_.
+
+To work easier with TextMate YAML language files install VSCode extension e.g.
+[TextMate Languages](https://marketplace.visualstudio.com/items?itemName=Togusa09.tmlanguage)
+from _Ben Hockley_.
+
+* Use commands _"Convert to YAML-tmLanguage file"_ and
+  _"Convert to tmLanguage file"_ provided by extension _TextMate Languages_.
+
+* Alternatively download
+  [grahampugh/plist-yaml-plist](https://github.com/grahampugh/plist-yaml-plist)
+  from Github and use below commands: (On Windows use e.g. WSL)
+
+  ```bash
+  /path/to/plist_yaml.py Erlang.plist Erlang.yaml
+  # Edit YAML file here ... then if you are ready convert back to PLIST
+  /path/to/yaml_plist.py Erlang.yaml Erlang.plist
+  ```
+
+Commit your updates on `Erlang.plist` and ignode `Erlang.yaml`.
+
+See more:
+
+1. Visual Studio Code [Syntax Highlight Guide](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide)
+2. TextMate [Language Grammars](https://macromates.com/manual/en/language_grammars)
+3. [Writing a TextMate Grammar: Some Lessons Learned](https://www.apeth.com/nonblog/stories/textmatebundle.html)


### PR DESCRIPTION
Erlang.plist was copied from textmate/erlang.tmbundle [1] similarly as
it was copied to pgourlain/vscode_erlang [2] earlier. vscdoe_erlang had
several updates to resolve some issues in syntax highlighting before
switched to this repository as a submodule. This commit merges all of
those syntax updates here.

By Daniel Finke (commit 921bb3e [3]):
- Comma is not needed in '-define' on the same line as macro name

By Kornel Horvath (commit 921bb3e [3]):
- Allow comment between '}' and ').' in record definitions
- Allow variables as module or function names in implicit function
  expressions
- Distinguish function type in type specification and explicit function
  expression
- Assign file extensions to Erlang mode: escript, yrl, xrl

By Kornel Horvath (commit db9ef8b [4]):
- '$<space>' is a valid ASCII number
- Escape sequences '\^a'..'\^z' are valid (and same as '\^A'..'\^Z')
- Escape sequences '\xXY' (where XY are hexadecimal digits) are valid
- 'utf8', 'utf16' and 'utf32' are valid type specifiers in binary
- Binary unit type specifier has a mandatory parameters as
  'unit:<pos_integer>' (where <pos_integer> is in range 1..256)
- Single underscore (_) can be inserted between digits as a visual
  separator (since OTP 23)
- Highlight 'true', 'false' and 'undefined' language constants. Well,
  technically 'undefined' is not that but traditionally used like that.

[1] https://github.com/textmate/erlang.tmbundle
[2] https://github.com/pgourlain/vscode_erlang
[3] https://github.com/pgourlain/vscode_erlang/commit/921bb3edd4b984de0c41d94fe5269a0160005a0a
[4] https://github.com/pgourlain/vscode_erlang/commit/db9ef8b1ebcf9bce86fba459ca1a4730d6d724d1