### PR TITLE
Update `io:fwrite` and `io:fread` format control sequences

### DIFF
--- a/Erlang.plist
+++ b/Erlang.plist
@@ -2617,36 +2617,18 @@
 							<key>name</key>
 							<string>punctuation.separator.placeholder-parts.erlang</string>
 						</dict>
-						<key>12</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.placeholder-parts.erlang</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.placeholder-parts.erlang</string>
-						</dict>
-						<key>4</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.placeholder-parts.erlang</string>
-						</dict>
 						<key>6</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.separator.placeholder-parts.erlang</string>
 						</dict>
-						<key>8</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.placeholder-parts.erlang</string>
-						</dict>
 					</dict>
+					<key>comment</key>
+					<string>io:fwrite format contorl sequence</string>
 					<key>match</key>
-					<string>(~)((\-)?\d++|(\*))?((\.)(\d++|(\*)))?((\.)((\*)|.))?[~cfegswpWPBX#bx\+ni]</string>
+					<string>(~)((\-)?\d++|(\*))?((\.)(\d++|(\*))?((\.)((\*)|.))?)?[tlkK]*[~cfegswpWPBX#bx\+ni]</string>
 					<key>name</key>
-					<string>constant.other.placeholder.erlang</string>
+					<string>constant.character.format.placeholder.other.erlang</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -2656,16 +2638,13 @@
 							<key>name</key>
 							<string>punctuation.definition.placeholder.erlang</string>
 						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.separator.placeholder-parts.erlang</string>
-						</dict>
 					</dict>
+					<key>comment</key>
+					<string>io:fread format contorl sequence</string>
 					<key>match</key>
-					<string>(~)(\*)?(\d++)?[~du\-#fsacl]</string>
+					<string>(~)(\*)?(\d++)?(t)?[~du\-#fsacl]</string>
 					<key>name</key>
-					<string>constant.other.placeholder.erlang</string>
+					<string>constant.character.format.placeholder.other.erlang</string>
 				</dict>
 				<dict>
 					<key>match</key>


### PR DESCRIPTION
Updates:
- Add optional modifier characters, e.g. Unicode translation, etc.
- Fix optional parts of the regular expressions, e.g. to allow `~2..0b`.
- Use `constant.character.format.placeholder.other` textmate scope instead of `constant.other.placeholder` to make syntax highlight similar to other languages. Although, Python uses the first while C/C++ uses the second, first one seems to be more precise.

A simple example module to test the syntax highlight with the original and updated TextMate language definition:

```erlang
-module(format_string_syntax_highlight_example).

-export([f/0]).

f() ->
    io:format("[~f]~n", [3.14]),
    io:format("[~9f]~n", [3.14]),
    io:format("[~-9f]~n", [3.14]),
    io:format("[~*f]~n", [9, 3.14]),
    io:format("[~.f]~n", [3.14]),
    io:format("[~.3f]~n", [3.14]),
    io:format("[~.*f]~n", [3, 3.14]),
    io:format("[~9.f]~n", [3.14]),
    io:format("[~*.f]~n", [9, 3.14]),
    io:format("[~9.3f]~n", [3.14]),
    io:format("[~9.*f]~n", [3, 3.14]),
    io:format("[~*.3f]~n", [9, 3.14]),
    io:format("[~*.*f]~n", [9, 3, 3.14]),
    io:format("[~..0f]~n", [3.14]),
    io:format("[~.3.0f]~n", [3.14]),
    io:format("[~9..0f]~n", [3.14]),
    io:format("[~9.3.0f]~n", [3.14]),
    io:format("[~9.3.0f]~n", [3.14]),
    io:format("[~9.3.*f]~n", [$*, 3.14]),
    io:format("[~kp]~n", [#{z => "apple", a => [199 | "banana"]}]),
    io:format("[~Kp]~n", [reversed, #{z => "apple", a => [199 | "banana"]}]),
    io:format("[~Klp]~n", [reversed, #{z => "apple", a => [199 | "banana"]}]),
    io:format("[~ls]~n", [[199 | "banana"]]),
    io:format("[~-70.3._ts]~n", ["banana"]),
    io:fread("~d"),
    io:fread("~td"),
    io:fread("~10d"),
    io:fread("~10td"),
    io:fread("~*10d"),
    io:fread("~*10td"),
    ok.
```