### PR TITLE
Add sample for format control sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Erlang.yaml
 /Erlang.yml
+/node_modules/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,15 @@
         {
             "label": "Run tests",
             "type": "shell",
-            "command": "npx vscode-tmgrammar-test -c './tests/*.erl' && npx vscode-tmgrammar-snap './tests/snap/*.erl'",
+            "command": "npx vscode-tmgrammar-test -c ./tests/*.erl && npx vscode-tmgrammar-snap ./tests/snap/*.erl",
+            "windows": {
+                "options": {
+                    "shell": {
+                        "executable": "C:\\Windows\\System32\\cmd.exe",
+                        "args": ["/C"]
+                    }
+                }
+            },
             "group": "test",
             "presentation": {
                 "reveal": "always",

--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ from _Ben Hockley_.
 
 Commit your updates on `Erlang.plist` and ignode `Erlang.yaml`.
 
-To test the grammar we use [VSCode Textmate grammar test](https://github.com/PanAeon/vscode-tmgrammar-test),
-simply run `npm ci && npm test` and all tests will be run. To add more tests you can either add annotated files
-to `./tests/` or use the snapshot facility and then tests should be added to `./test/snap`.
+To test the grammar we use
+[VSCode Textmate grammar test](https://github.com/PanAeon/vscode-tmgrammar-test),
+simply run `npm ci && npm test` (or `npm ci` and `npm test` separately in
+PowerShell) and all tests will be run. To add more tests you can either add
+annotated files to `./tests/` or use the snapshot facility and then tests should
+be added to `./test/snap`.
 
 See more:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "vscode-tmgrammar-test './tests/*.erl' && vscode-tmgrammar-snap './tests/snap/*.erl'"
+    "test": "vscode-tmgrammar-test ./tests/*.erl && vscode-tmgrammar-snap ./tests/snap/*.erl"
   },
   "contributes": {
     "languages": [

--- a/tests/snap/format_control_sequences.erl
+++ b/tests/snap/format_control_sequences.erl
@@ -1,0 +1,37 @@
+-module(format_control_sequences).
+
+-export([f/0]).
+
+f() ->
+    io:format("[~f]~n", [3.14]),
+    io:format("[~9f]~n", [3.14]),
+    io:format("[~-9f]~n", [3.14]),
+    io:format("[~*f]~n", [9, 3.14]),
+    io:format("[~.f]~n", [3.14]),
+    io:format("[~.3f]~n", [3.14]),
+    io:format("[~.*f]~n", [3, 3.14]),
+    io:format("[~9.f]~n", [3.14]),
+    io:format("[~*.f]~n", [9, 3.14]),
+    io:format("[~9.3f]~n", [3.14]),
+    io:format("[~9.*f]~n", [3, 3.14]),
+    io:format("[~*.3f]~n", [9, 3.14]),
+    io:format("[~*.*f]~n", [9, 3, 3.14]),
+    io:format("[~..0f]~n", [3.14]),
+    io:format("[~.3.0f]~n", [3.14]),
+    io:format("[~9..0f]~n", [3.14]),
+    io:format("[~9.3.0f]~n", [3.14]),
+    io:format("[~9.3.0f]~n", [3.14]),
+    io:format("[~9.3.*f]~n", [$*, 3.14]),
+    io:format("[~kp]~n", [#{z => "apple", a => [199 | "banana"]}]),
+    io:format("[~Kp]~n", [reversed, #{z => "apple", a => [199 | "banana"]}]),
+    io:format("[~Klp]~n", [reversed, #{z => "apple", a => [199 | "banana"]}]),
+    io:format("[~lp]~n", [[199 | "banana"]]),
+    io:format("[~-70.3._ts]~n", ["banana"]),
+
+    io:fread("~d"),
+    io:fread("~td"),
+    io:fread("~10d"),
+    io:fread("~10td"),
+    io:fread("~*10d"),
+    io:fread("~*10td"),
+    ok.

--- a/tests/snap/format_control_sequences.erl.snap
+++ b/tests/snap/format_control_sequences.erl.snap
@@ -1,0 +1,803 @@
+>-module(format_control_sequences).
+#^ source.erlang meta.directive.module.erlang punctuation.section.directive.begin.erlang
+# ^^^^^^ source.erlang meta.directive.module.erlang keyword.control.directive.module.erlang
+#       ^ source.erlang meta.directive.module.erlang punctuation.definition.parameters.begin.erlang
+#        ^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.module.erlang entity.name.type.class.module.definition.erlang
+#                                ^ source.erlang meta.directive.module.erlang punctuation.definition.parameters.end.erlang
+#                                 ^ source.erlang meta.directive.module.erlang punctuation.section.directive.end.erlang
+>
+>-export([f/0]).
+#^ source.erlang meta.directive.export.erlang punctuation.section.directive.begin.erlang
+# ^^^^^^ source.erlang meta.directive.export.erlang keyword.control.directive.export.erlang
+#       ^ source.erlang meta.directive.export.erlang punctuation.definition.parameters.begin.erlang
+#        ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.definition.list.begin.erlang
+#         ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#          ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#           ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#            ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.definition.list.end.erlang
+#             ^ source.erlang meta.directive.export.erlang punctuation.definition.parameters.end.erlang
+#              ^ source.erlang meta.directive.export.erlang punctuation.section.directive.end.erlang
+>
+>f() ->
+#^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+# ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#   ^ source.erlang meta.function.erlang
+#    ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+>    io:format("[~f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                           ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                               ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                            ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~-9f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                             ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                 ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~*f]~n", [9, 3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                               ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                   ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~.f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                            ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~.3f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                             ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                 ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~.*f]~n", [3, 3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                    ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9.f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                             ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                 ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~*.f]~n", [9, 3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                    ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9.3f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                              ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                  ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9.*f]~n", [3, 3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                 ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                    ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                     ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~*.3f]~n", [9, 3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                 ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                    ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                     ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~*.*f]~n", [9, 3, 3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                    ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                      ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                        ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~..0f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                              ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                  ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~.3.0f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                    ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                               ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                   ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9..0f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                    ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                               ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                   ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9.3.0f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                     ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                    ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9.3.0f]~n", [3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                     ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                    ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~9.3.*f]~n", [$*, 3.14]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                     ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.character.erlang punctuation.definition.character.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.character.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang punctuation.separator.integer-float.erlang
+#                                    ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.numeric.float.erlang
+#                                      ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                        ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~kp]~n", [#{z => "apple", a => [199 | "banana"]}]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.definition.tuple.begin.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang constant.other.symbol.unquoted.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                  ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang
+#                                       ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.separator.tuple.erlang
+#                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang constant.other.symbol.unquoted.erlang
+#                                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                                                ^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang
+#                                                    ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                                     ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang
+#                                                      ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                                       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang
+#                                                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.definition.tuple.end.erlang
+#                                                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                                                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                                                  ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~Kp]~n", [reversed, #{z => "apple", a => [199 | "banana"]}]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                          ^^^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.other.symbol.unquoted.erlang
+#                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                   ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                                     ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.definition.tuple.begin.erlang
+#                                      ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang constant.other.symbol.unquoted.erlang
+#                                       ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                            ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang
+#                                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.separator.tuple.erlang
+#                                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                                    ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang constant.other.symbol.unquoted.erlang
+#                                                     ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                                      ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                                       ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                                                          ^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                                                             ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang
+#                                                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang
+#                                                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                                                 ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang
+#                                                                       ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.definition.tuple.end.erlang
+#                                                                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                                                           ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                                                            ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~Klp]~n", [reversed, #{z => "apple", a => [199 | "banana"]}]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                           ^^^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang constant.other.symbol.unquoted.erlang
+#                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                    ^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang
+#                                      ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.definition.tuple.begin.erlang
+#                                       ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang constant.other.symbol.unquoted.erlang
+#                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                            ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                             ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang
+#                                                  ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                                   ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.separator.tuple.erlang
+#                                                    ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                                     ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang constant.other.symbol.unquoted.erlang
+#                                                      ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                                       ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang keyword.operator.symbolic.erlang
+#                                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang
+#                                                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                                                           ^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                                                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang
+#                                                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang
+#                                                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                                                  ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang
+#                                                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                                                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.tuple.erlang punctuation.definition.tuple.end.erlang
+#                                                                           ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                                                            ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                                                             ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~lp]~n", [[199 | "banana"]]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                       ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                        ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                           ^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang constant.numeric.integer.decimal.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang punctuation.separator.list.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                  ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang string.quoted.double.erlang
+#                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                          ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                           ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                            ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:format("[~-70.3._ts]~n", ["banana"]),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                 ^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                       ^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                          ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang
+#                           ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#                            ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                             ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                              ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                               ^ source.erlang meta.function.erlang meta.function-call.erlang
+#                                ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.begin.erlang
+#                                 ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                                  ^^^^^^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang string.quoted.double.erlang
+#                                        ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                                         ^ source.erlang meta.function.erlang meta.function-call.erlang meta.structure.list.erlang punctuation.definition.list.end.erlang
+#                                          ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                                           ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>
+>    io:fread("~d"),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#            ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                  ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:fread("~td"),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#            ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                   ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:fread("~10d"),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#            ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                    ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:fread("~10td"),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#            ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                     ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:fread("~*10d"),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#            ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                     ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    io:fread("~*10td"),
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#       ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#            ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                      ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    ok.
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#      ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>


### PR DESCRIPTION
Add an example file for visual inspection of syntax highlight of `io:fwrite` and `io:fread` format control sequences.

It is a follow up for pull request #8.