### PR TITLE
Add docstrings as per Erlang/OTP 27

### DIFF
--- a/Erlang.plist
+++ b/Erlang.plist
@@ -536,6 +536,219 @@
 				</dict>
 			</array>
 		</dict>
+		<key>docstring</key>
+		<dict>
+			<key>comment</key>
+			<string>It is possible to use more than 3 double quote characters as beginning and closing sequences (must be the same). Cover 3-9 characters here.</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#docstring3</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#docstring4</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#docstring5</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#docstring6</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#docstring7</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#docstring8</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#docstring9</string>
+				</dict>
+			</array>
+		</dict>
+		<key>docstring3</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!")(["]{3}\s*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.begin.erlang</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Only whitespace characters are allowed after the beggining and before the closing sequences and those cannot be in the same line</string>
+			<key>end</key>
+			<string>^(\s*["]{3})(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.string.docstring.multi.erlang</string>
+		</dict>
+		<key>docstring4</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!")(["]{4}\s*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.begin.erlang</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(\s*["]{4})(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.string.docstring.multi.erlang</string>
+		</dict>
+		<key>docstring5</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!")(["]{5}\s*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.begin.erlang</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(\s*["]{5})(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.string.docstring.multi.erlang</string>
+		</dict>
+		<key>docstring6</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!")(["]{6}\s*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.begin.erlang</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(\s*["]{6})(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.string.docstring.multi.erlang</string>
+		</dict>
+		<key>docstring7</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!")(["]{7}\s*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.begin.erlang</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(\s*["]{7})(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.string.docstring.multi.erlang</string>
+		</dict>
+		<key>docstring8</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!")(["]{8}\s*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.begin.erlang</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(\s*["]{8})(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.string.docstring.multi.erlang</string>
+		</dict>
+		<key>docstring9</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;!")(["]{9}\s*)$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.begin.erlang</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(\s*["]{9})(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.docstring.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.string.docstring.multi.erlang</string>
+		</dict>
 		<key>everything-else</key>
 		<dict>
 			<key>patterns</key>
@@ -599,6 +812,10 @@
 				<dict>
 					<key>include</key>
 					<string>#atom</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#docstring</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -2593,6 +2810,8 @@
 							<string>punctuation.definition.escape.erlang</string>
 						</dict>
 					</dict>
+					<key>comment</key>
+					<string>escape sequence</string>
 					<key>match</key>
 					<string>(\\)([bdefnrstv\\'"]|(\^)[@-_a-z]|[0-7]{1,3}|x[\da-fA-F]{2})</string>
 					<key>name</key>

--- a/README.md
+++ b/README.md
@@ -56,10 +56,15 @@ from _Ben Hockley_.
   from Github and use below commands: (On Windows use e.g. WSL)
 
   ```bash
-  /path/to/plist_yaml.py Erlang.plist Erlang.yaml
+  /path/to/plistyamlplist.py Erlang.plist Erlang.yaml
   # Edit YAML file here ... then if you are ready convert back to PLIST
-  /path/to/yaml_plist.py Erlang.yaml Erlang.plist
+  /path/to/plistyamlplist.py Erlang.yaml Erlang.plist
   ```
+
+  > Note:
+  > Please read
+  > [Issue with Python 3.11](https://github.com/grahampugh/plist-yaml-plist/issues/15)
+  > if you get a strange error when convert PLIST to YAML or vice versa.
 
 Commit your updates on `Erlang.plist` and ignode `Erlang.yaml`.
 

--- a/tests/snap/docstring.erl
+++ b/tests/snap/docstring.erl
@@ -1,0 +1,33 @@
+-module(docstring).
+
+-export([f/0]).
+
+-doc """
+     Docstring examples
+     """.
+f() ->
+    """
+  Line "1"
+  Line "2"
+  """ = "Line \"1\"
+Line \"2\"",
+    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+
+    """
+      First line starting with two spaces
+    Not escaped: "\t \r \xFF" and """
+
+    """ = "  First line starting with two spaces
+Not escaped: \"\\t \\r \\xFF\" and \"\"\"
+",
+    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+
+    """""
+""""
+FIXME: previous line is not a closing delimiter because opening-closing delimiter have five double quote characters
+""""" = "\"\"\"\"",
+    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+
+    ok.
+
+-define(THIS_IS_THE_END, "end"). % just to check is syntax highlight is still ok

--- a/tests/snap/docstring.erl.snap
+++ b/tests/snap/docstring.erl.snap
@@ -1,0 +1,205 @@
+>-module(docstring).
+#^ source.erlang meta.directive.module.erlang punctuation.section.directive.begin.erlang
+# ^^^^^^ source.erlang meta.directive.module.erlang keyword.control.directive.module.erlang
+#       ^ source.erlang meta.directive.module.erlang punctuation.definition.parameters.begin.erlang
+#        ^^^^^^^^^ source.erlang meta.directive.module.erlang entity.name.type.class.module.definition.erlang
+#                 ^ source.erlang meta.directive.module.erlang punctuation.definition.parameters.end.erlang
+#                  ^ source.erlang meta.directive.module.erlang punctuation.section.directive.end.erlang
+>
+>-export([f/0]).
+#^ source.erlang meta.directive.export.erlang punctuation.section.directive.begin.erlang
+# ^^^^^^ source.erlang meta.directive.export.erlang keyword.control.directive.export.erlang
+#       ^ source.erlang meta.directive.export.erlang punctuation.definition.parameters.begin.erlang
+#        ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.definition.list.begin.erlang
+#         ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#          ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#           ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#            ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.definition.list.end.erlang
+#             ^ source.erlang meta.directive.export.erlang punctuation.definition.parameters.end.erlang
+#              ^ source.erlang meta.directive.export.erlang punctuation.section.directive.end.erlang
+>
+>-doc """
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang
+#     ^^^^ source.erlang meta.directive.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.begin.erlang
+>     Docstring examples
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.string.docstring.multi.erlang
+>     """.
+#^^^^^^^^ source.erlang meta.directive.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.end.erlang
+#        ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+>f() ->
+#^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+# ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#   ^ source.erlang meta.function.erlang
+#    ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+>    """
+#^^^^ source.erlang meta.function.erlang
+#    ^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.begin.erlang
+>  Line "1"
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang
+>  Line "2"
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang
+>  """ = "Line \"1\"
+#^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.end.erlang
+#     ^ source.erlang meta.function.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#         ^^^^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.double.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                  ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+>Line \"2\"",
+#^^^^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#     ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#      ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#       ^ source.erlang meta.function.erlang string.quoted.double.erlang
+#        ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#         ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#          ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#           ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+#^^^^ source.erlang meta.function.erlang
+#    ^ source.erlang meta.function.erlang variable.other.erlang
+#     ^ source.erlang meta.function.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#              ^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                      ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+#                       ^ source.erlang meta.function.erlang
+#                        ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
+>
+>    """
+#^^^^ source.erlang meta.function.erlang
+#    ^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.begin.erlang
+>      First line starting with two spaces
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang
+>    Not escaped: "\t \r \xFF" and """
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang
+>
+>    """ = "  First line starting with two spaces
+#^^^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.end.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#         ^ source.erlang meta.function.erlang
+#          ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.double.erlang
+>Not escaped: \"\\t \\r \\xFF\" and \"\"\"
+#^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                 ^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#                   ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                    ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                     ^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#                       ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                        ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                         ^^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#                            ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                             ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                              ^^^^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#                                   ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                                    ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                                     ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                                      ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                                       ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                                        ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+>",
+#^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+# ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+#^^^^ source.erlang meta.function.erlang
+#    ^ source.erlang meta.function.erlang variable.other.erlang
+#     ^ source.erlang meta.function.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#              ^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                      ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+#                       ^ source.erlang meta.function.erlang
+#                        ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
+>
+>    """""
+#^^^^ source.erlang meta.function.erlang
+#    ^^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.begin.erlang
+>""""
+#^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang
+>FIXME: previous line is not a closing delimiter because opening-closing delimiter have five double quote characters
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang
+>""""" = "\"\"\"\"",
+#^^^^^ source.erlang meta.function.erlang string.string.docstring.multi.erlang punctuation.definition.docstring.end.erlang
+#     ^ source.erlang meta.function.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#         ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#          ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                  ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+#^^^^ source.erlang meta.function.erlang
+#    ^ source.erlang meta.function.erlang variable.other.erlang
+#     ^ source.erlang meta.function.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#              ^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                      ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+#                       ^ source.erlang meta.function.erlang
+#                        ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
+>
+>    ok.
+#^^^^ source.erlang meta.function.erlang
+#    ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#      ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-define(THIS_IS_THE_END, "end"). % just to check is syntax highlight is still ok
+#^ source.erlang meta.directive.define.erlang punctuation.section.directive.begin.erlang
+# ^^^^^^ source.erlang meta.directive.define.erlang keyword.control.directive.define.erlang
+#       ^ source.erlang meta.directive.define.erlang punctuation.definition.parameters.begin.erlang
+#        ^^^^^^^^^^^^^^^ source.erlang meta.directive.define.erlang entity.name.function.macro.definition.erlang
+#                       ^^ source.erlang meta.directive.define.erlang
+#                         ^ source.erlang meta.directive.define.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#                          ^^^ source.erlang meta.directive.define.erlang string.quoted.double.erlang
+#                             ^ source.erlang meta.directive.define.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                              ^ source.erlang meta.directive.define.erlang punctuation.definition.parameters.end.erlang
+#                               ^ source.erlang meta.directive.define.erlang punctuation.section.directive.end.erlang
+#                                ^ source.erlang
+#                                 ^ source.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang comment.line.percentage.erlang
+>


### PR DESCRIPTION
Erlang/OTP 27 [1] introduces triple-quoted strings (docstrings) [2].

[1] https://www.erlang.org/news/168
[2] https://www.erlang.org/docs/27/system/data_types.html#string