### PR TITLE
Highlight module and function docstrings as comments

### DIFF
--- a/Erlang.plist
+++ b/Erlang.plist
@@ -577,6 +577,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.triple.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>everything-else</key>
 		<dict>
@@ -645,6 +652,10 @@
 				<dict>
 					<key>include</key>
 					<string>#sigil-docstring</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#sigil-docstring-verbatim</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1656,6 +1667,16 @@
 					<key>name</key>
 					<string>invalid.illegal.string.erlang</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
+		</dict>
+		<key>internal-string-body-verbatim</key>
+		<dict>
+			<key>patterns</key>
+			<array>
 				<dict>
 					<key>captures</key>
 					<dict>
@@ -2691,7 +2712,7 @@
 		<key>sigil-docstring</key>
 		<dict>
 			<key>begin</key>
-			<string>(~[bBsS]?)((["]{3,})\s*)(\S.*)?$</string>
+			<string>(~[bs])((["]{3,})\s*)(\S.*)?$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -2734,6 +2755,67 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.tripple.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body</string>
+				</dict>
+			</array>
+		</dict>
+		<key>sigil-docstring-verbatim</key>
+		<dict>
+			<key>begin</key>
+			<string>(~[BS]?)((["]{3,})\s*)(\S.*)?$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.string.erlang</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>meta.string.quoted.triple.begin.erlang</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.erlang</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.illegal.string.erlang</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>Only whitespace characters are allowed after the beggining and before the closing sequences and those cannot be in the same line</string>
+			<key>end</key>
+			<string>^(\s*(\3))(?!")</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>meta.string.quoted.triple.end.erlang</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.quoted.tripple.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>sigil-string</key>
 		<dict>
@@ -2863,6 +2945,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.curly-brackets.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>sigil-string-double-quote</key>
 		<dict>
@@ -2930,6 +3019,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.double.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>sigil-string-less-greater</key>
 		<dict>
@@ -2997,6 +3093,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.less-greater.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>sigil-string-parenthesis</key>
 		<dict>
@@ -3064,6 +3167,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.parenthesis.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>sigil-string-single-character</key>
 		<dict>
@@ -3131,6 +3241,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.other.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>sigil-string-single-quote</key>
 		<dict>
@@ -3198,6 +3315,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.single.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>sigil-string-square-brackets</key>
 		<dict>
@@ -3265,6 +3389,13 @@
 			</dict>
 			<key>name</key>
 			<string>string.quoted.square-brackets.sigil.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#internal-string-body-verbatim</string>
+				</dict>
+			</array>
 		</dict>
 		<key>string</key>
 		<dict>

--- a/Erlang.plist
+++ b/Erlang.plist
@@ -44,6 +44,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#doc-directive</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#directive</string>
 		</dict>
 		<dict>
@@ -533,6 +537,82 @@
 					<string>^\s*+(-)\s*+([a-z][a-zA-Z\d@_]*+)\s*+(\.)</string>
 					<key>name</key>
 					<string>meta.directive.erlang</string>
+				</dict>
+			</array>
+		</dict>
+		<key>doc-directive</key>
+		<dict>
+			<key>begin</key>
+			<string>^\s*+(-)\s*+((module)?doc)\s*([(]\s*)?(~[bBsS]?)?((["]{3,})\s*)(\S.*)?$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.directive.begin.erlang</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.directive.doc.erlang</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.parameters.begin.erlang</string>
+				</dict>
+				<key>5</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.string.erlang</string>
+				</dict>
+				<key>6</key>
+				<dict>
+					<key>name</key>
+					<string>comment.block.documentation.erlang</string>
+				</dict>
+				<key>7</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.erlang</string>
+				</dict>
+				<key>8</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.illegal.string.erlang</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(\s*(\7))\s*([)]\s*)?(\.)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>comment.block.documentation.erlang</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.erlang</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.directive.end.Erlang</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.directive.doc.erlang</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\G</string>
+					<key>contentName</key>
+					<string>comment.block.documentation.erlang</string>
+					<key>while</key>
+					<string>(^)(?!\s*(\5))</string>
 				</dict>
 			</array>
 		</dict>

--- a/tests/snap/docstring.erl
+++ b/tests/snap/docstring.erl
@@ -1,11 +1,17 @@
 -module(docstring).
+-moduledoc """
+Triple quoted strings examples
+""".
 
--export([f/0]).
+-export([f1/0, f2/0, f3/0, f4/0, f5/0,
+         g1/0, g2/0, g3/0, g4/0, g5/0]).
+
+%% -doc attributes without parentheses
 
 -doc """
      Docstring examples
      """.
-f() ->
+f1() ->
     """
   Line "1"
   Line "2"
@@ -24,10 +30,45 @@ Not escaped: \"\\t \\r \\xFF\" and \"\"\"
 
     """""
 """"
-FIXME: previous line is not a closing delimiter because opening-closing delimiter have five double quote characters
+previous line is not a closing delimiter because opening-closing delimiter have five double quote characters
 """"" = "\"\"\"\"",
     X = lists:seq(1,3), % just to check is syntax highlight is still ok
 
     ok.
+
+-doc ~s"""""
+      Hello\n
+      """"".
+f2() -> ok.
+
+-doc "Hello\n".
+f3() -> ok.
+
+-doc ~s"Hello\n".
+f4() -> ok.
+
+-doc <<"Hello\n"/utf8>>.
+f5() -> ok.
+
+%% -doc attributes with parentheses
+
+-doc("""
+     Hello\n
+     """).
+g1() -> ok.
+
+-doc(~B"""""
+      Hello\n
+      """"").
+g2() -> ok.
+
+-doc("Hello\n").
+g3() -> ok.
+
+-doc(~B"Hello\n").
+g4() -> ok.
+
+-doc(<<"Hello\n"/utf8>>).
+g5() -> ok.
 
 -define(THIS_IS_THE_END, "end"). % just to check is syntax highlight is still ok

--- a/tests/snap/docstring.erl.snap
+++ b/tests/snap/docstring.erl.snap
@@ -5,37 +5,97 @@
 #        ^^^^^^^^^ source.erlang meta.directive.module.erlang entity.name.type.class.module.definition.erlang
 #                 ^ source.erlang meta.directive.module.erlang punctuation.definition.parameters.end.erlang
 #                  ^ source.erlang meta.directive.module.erlang punctuation.section.directive.end.erlang
+>-moduledoc """
+#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
+# ^^^^^^^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
+#          ^ source.erlang meta.directive.doc.erlang
+#           ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+>Triple quoted strings examples
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+>""".
+#^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
+#   ^ source.erlang meta.directive.doc.erlang
 >
->-export([f/0]).
+>-export([f1/0, f2/0, f3/0, f4/0, f5/0,
 #^ source.erlang meta.directive.export.erlang punctuation.section.directive.begin.erlang
 # ^^^^^^ source.erlang meta.directive.export.erlang keyword.control.directive.export.erlang
 #       ^ source.erlang meta.directive.export.erlang punctuation.definition.parameters.begin.erlang
 #        ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.definition.list.begin.erlang
-#         ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
-#          ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
-#           ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
-#            ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.definition.list.end.erlang
-#             ^ source.erlang meta.directive.export.erlang punctuation.definition.parameters.end.erlang
-#              ^ source.erlang meta.directive.export.erlang punctuation.section.directive.end.erlang
+#         ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#           ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#            ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#             ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#              ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#               ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                 ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                  ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                   ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#                    ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#                     ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                       ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                        ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                         ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#                          ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#                           ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                             ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                              ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                               ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#                                ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#                                 ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                                   ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                                    ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                                     ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+>         g1/0, g2/0, g3/0, g4/0, g5/0]).
+#^^^^^^^^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#         ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#           ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#            ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#             ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#              ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#               ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                 ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                  ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                   ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#                    ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#                     ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                       ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                        ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                         ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#                          ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#                           ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                             ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                              ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                               ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.list.erlang
+#                                ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang
+#                                 ^^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang entity.name.function.erlang
+#                                   ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.separator.function-arity.erlang
+#                                    ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang constant.numeric.integer.decimal.erlang
+#                                     ^ source.erlang meta.directive.export.erlang meta.structure.list.function.erlang punctuation.definition.list.end.erlang
+#                                      ^ source.erlang meta.directive.export.erlang punctuation.definition.parameters.end.erlang
+#                                       ^ source.erlang meta.directive.export.erlang punctuation.section.directive.end.erlang
+>
+>%% -doc attributes without parentheses
+#^ source.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang comment.line.percentage.erlang
 >
 >-doc """
-#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
-# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
-#    ^ source.erlang meta.directive.erlang
-#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
+#    ^ source.erlang meta.directive.doc.erlang
+#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
 >     Docstring examples
-#^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
 >     """.
-#^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang
-#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
-#        ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
->f() ->
-#^ source.erlang meta.function.erlang entity.name.function.definition.erlang
-# ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
-#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
-#   ^ source.erlang meta.function.erlang
-#    ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
+#        ^ source.erlang meta.directive.doc.erlang
+>f1() ->
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
 #     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
 >    """
 #^^^^ source.erlang meta.function.erlang
 #    ^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
@@ -149,8 +209,8 @@
 #    ^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >""""
 #^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang
->FIXME: previous line is not a closing delimiter because opening-closing delimiter have five double quote characters
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang
+>previous line is not a closing delimiter because opening-closing delimiter have five double quote characters
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang
 >""""" = "\"\"\"\"",
 #^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #     ^ source.erlang meta.function.erlang
@@ -190,6 +250,217 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
 #      ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc ~s"""""
+#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
+#    ^ source.erlang meta.directive.doc.erlang
+#     ^^ source.erlang meta.directive.doc.erlang storage.type.string.erlang
+#       ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+>      Hello\n
+#^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+>      """"".
+#^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#      ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
+#           ^ source.erlang meta.directive.doc.erlang
+>f2() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc "Hello\n".
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang
+#     ^ source.erlang meta.directive.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#      ^^^^^ source.erlang meta.directive.erlang string.quoted.double.erlang
+#           ^ source.erlang meta.directive.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#            ^ source.erlang meta.directive.erlang string.quoted.double.erlang constant.character.escape.erlang
+#             ^ source.erlang meta.directive.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#              ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+>f3() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc ~s"Hello\n".
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang
+#     ^^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang storage.type.string.erlang
+#       ^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang punctuation.definition.string.begin.erlang
+#        ^^^^^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang
+#             ^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#              ^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang constant.character.escape.erlang
+#               ^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang punctuation.definition.string.end.erlang
+#                ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+>f4() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc <<"Hello\n"/utf8>>.
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang
+#     ^^ source.erlang meta.directive.erlang meta.structure.binary.erlang punctuation.definition.binary.begin.erlang
+#       ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#        ^^^^^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang
+#             ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#              ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang constant.character.escape.erlang
+#               ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                ^ source.erlang meta.directive.erlang meta.structure.binary.erlang punctuation.separator.value-type.erlang
+#                 ^^^^ source.erlang meta.directive.erlang meta.structure.binary.erlang storage.type.erlang
+#                     ^^ source.erlang meta.directive.erlang meta.structure.binary.erlang punctuation.definition.binary.end.erlang
+#                       ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+>f5() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>%% -doc attributes with parentheses
+#^ source.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang comment.line.percentage.erlang
+>
+>-doc("""
+#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
+#    ^ source.erlang meta.directive.doc.erlang punctuation.definition.parameters.begin.erlang
+#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+>     Hello\n
+#^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+>     """).
+#^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
+#        ^ source.erlang meta.directive.doc.erlang punctuation.section.directive.end.Erlang
+#         ^ source.erlang meta.directive.doc.erlang
+>g1() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc(~B"""""
+#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
+#    ^ source.erlang meta.directive.doc.erlang punctuation.definition.parameters.begin.erlang
+#     ^^ source.erlang meta.directive.doc.erlang storage.type.string.erlang
+#       ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+>      Hello\n
+#^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+>      """"").
+#^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#      ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
+#           ^ source.erlang meta.directive.doc.erlang punctuation.section.directive.end.Erlang
+#            ^ source.erlang meta.directive.doc.erlang
+>g2() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc("Hello\n").
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang punctuation.definition.parameters.begin.erlang
+#     ^ source.erlang meta.directive.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#      ^^^^^ source.erlang meta.directive.erlang string.quoted.double.erlang
+#           ^ source.erlang meta.directive.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#            ^ source.erlang meta.directive.erlang string.quoted.double.erlang constant.character.escape.erlang
+#             ^ source.erlang meta.directive.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#              ^ source.erlang meta.directive.erlang punctuation.definition.parameters.end.erlang
+#               ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+>g3() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc(~B"Hello\n").
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang punctuation.definition.parameters.begin.erlang
+#     ^^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang storage.type.string.erlang
+#       ^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang punctuation.definition.string.begin.erlang
+#        ^^^^^^^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang
+#               ^ source.erlang meta.directive.erlang string.quoted.double.sigil.erlang punctuation.definition.string.end.erlang
+#                ^ source.erlang meta.directive.erlang punctuation.definition.parameters.end.erlang
+#                 ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+>g4() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
+>
+>-doc(<<"Hello\n"/utf8>>).
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang punctuation.definition.parameters.begin.erlang
+#     ^^ source.erlang meta.directive.erlang meta.structure.binary.erlang punctuation.definition.binary.begin.erlang
+#       ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#        ^^^^^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang
+#             ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#              ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang constant.character.escape.erlang
+#               ^ source.erlang meta.directive.erlang meta.structure.binary.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                ^ source.erlang meta.directive.erlang meta.structure.binary.erlang punctuation.separator.value-type.erlang
+#                 ^^^^ source.erlang meta.directive.erlang meta.structure.binary.erlang storage.type.erlang
+#                     ^^ source.erlang meta.directive.erlang meta.structure.binary.erlang punctuation.definition.binary.end.erlang
+#                       ^ source.erlang meta.directive.erlang punctuation.definition.parameters.end.erlang
+#                        ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+>g5() -> ok.
+#^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
+#  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
+#   ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.end.erlang
+#    ^ source.erlang meta.function.erlang
+#     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#       ^ source.erlang meta.function.erlang
+#        ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
+#          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
 >
 >-define(THIS_IS_THE_END, "end"). % just to check is syntax highlight is still ok
 #^ source.erlang meta.directive.define.erlang punctuation.section.directive.begin.erlang

--- a/tests/snap/sigil.erl
+++ b/tests/snap/sigil.erl
@@ -49,7 +49,9 @@ f() ->
     ~s'monkey ~2..0b\n',
     ~S'monkey ~2..0b\n', % verbatim
 
-     ~"monkey ~2..0b\n",
+      "monkey ~2..0b\n", % '' == '~s'
+
+     ~"monkey ~2..0b\n", % '~' == '~b'
     ~b"monkey ~2..0b\n",
     ~B"monkey ~2..0b\n", % verbatim
     ~s"monkey ~2..0b\n",
@@ -67,35 +69,47 @@ f() ->
     ~s#monkey ~2..0b\n#,
     ~S#monkey ~2..0b\n#, % verbatim
 
-    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+    _X = lists:seq(1,3), % just to check is syntax highlight is still ok
     ok.
 
 -spec g() -> ok. % just to check is syntax highlight is still ok
 g() ->
+    %% verbatim ('' == '~S' for triple-quoted strings)
+    """
+    monkey ~2..0b\n
+    business
+    """,
+
+    %% verbatim ('~' == '~B' for triple-quoted strings)
     ~"""
     monkey ~2..0b\n
     business
     """,
+
     ~b""""
     monkey ~2..0b\n
     """
     business
     """",
+
     ~B"""""
     monkey ~2..0b\n
     """
     business
     """"",
+
     ~s""""""
     monkey ~2..0b\n
     """
     business
     """""",
+
     ~S"""""""
     monkey ~2..0b\n
     """
     business
     """"""",
+
     X = lists:seq(1,3), % just to check is syntax highlight is still ok
 
     <<"\"\\µA\""/utf8>> = <<$",$\\,194,181,$A,$">> =
@@ -107,7 +121,7 @@ g() ->
           """ = ~B<"\µA"> =
         ~"""
           "\µA"
-          """ = ~"\"\\µA\"" = ~/"\\µA"/
+          """ = ~"\"\\µA\"" = ~/"\\µA"/,
     X = lists:seq(1,3), % just to check is syntax highlight is still ok
 
     [$",$\\,$µ,$A,$"] =
@@ -119,7 +133,7 @@ g() ->
           """ = ~S("\µA") =
         """
         "\µA"
-        """ = "\"\\µA\""
+        """ = "\"\\µA\"",
     X = lists:seq(1,3), % just to check is syntax highlight is still ok
 
     ok.

--- a/tests/snap/sigil.erl.snap
+++ b/tests/snap/sigil.erl.snap
@@ -24,16 +24,16 @@
 #                   ^ source.erlang meta.directive.export.erlang punctuation.section.directive.end.erlang
 >
 >-doc """
-#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
-# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
-#    ^ source.erlang meta.directive.erlang
-#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
+#    ^ source.erlang meta.directive.doc.erlang
+#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
 >     Sigil examples
-#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang
+#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
 >     """.
-#^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang
-#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
-#        ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
+#^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
+#        ^ source.erlang meta.directive.doc.erlang
 >-spec f() -> ok.
 #^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
 # ^^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang

--- a/tests/snap/sigil.erl.snap
+++ b/tests/snap/sigil.erl.snap
@@ -86,7 +86,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -110,7 +116,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.parenthesis.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -149,7 +161,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -173,7 +191,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.curly-brackets.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -212,7 +236,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -236,7 +266,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.square-brackets.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -275,7 +311,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -299,7 +341,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.less-greater.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -338,7 +386,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -362,7 +416,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -401,7 +461,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -425,7 +491,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -464,7 +536,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -488,14 +566,37 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.single.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
 #                         ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
 #                          ^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
 >
->     ~"monkey ~2..0b\n",
+>      "monkey ~2..0b\n", % '' == '~s'
+#^^^^^^ source.erlang meta.function.erlang
+#      ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.begin.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.double.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.format.placeholder.other.erlang
+#                    ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                     ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
+#                      ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+#                        ^ source.erlang meta.function.erlang
+#                         ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#                          ^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
+>
+>     ~"monkey ~2..0b\n", % '~' == '~b'
 #^^^^^ source.erlang meta.function.erlang
 #     ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang punctuation.definition.string.begin.erlang
@@ -509,6 +610,9 @@
 #                     ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.escape.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+#                        ^ source.erlang meta.function.erlang
+#                         ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#                          ^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
 >    ~b"monkey ~2..0b\n",
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang storage.type.string.erlang
@@ -527,7 +631,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -551,7 +661,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.double.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -590,7 +706,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -614,7 +736,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -653,7 +781,13 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
@@ -677,31 +811,37 @@
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang storage.type.string.erlang
 #      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.begin.erlang
-#       ^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#       ^^^^^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#               ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#                  ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.format.placeholder.other.erlang
+#                    ^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
 #                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 #                        ^ source.erlang meta.function.erlang
 #                         ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
 #                          ^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
 >
->    X = lists:seq(1,3), % just to check is syntax highlight is still ok
+>    _X = lists:seq(1,3), % just to check is syntax highlight is still ok
 #^^^^ source.erlang meta.function.erlang
-#    ^ source.erlang meta.function.erlang variable.other.erlang
-#     ^ source.erlang meta.function.erlang
-#      ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
-#       ^ source.erlang meta.function.erlang
-#        ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
-#             ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
-#              ^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
-#                 ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
-#                  ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
-#                   ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
-#                    ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
-#                     ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
-#                      ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
-#                       ^ source.erlang meta.function.erlang
-#                        ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
-#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
+#    ^^ source.erlang meta.function.erlang variable.other.erlang
+#      ^ source.erlang meta.function.erlang
+#       ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+#        ^ source.erlang meta.function.erlang
+#         ^^^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.type.class.module.erlang
+#              ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.module-function.erlang
+#               ^^^ source.erlang meta.function.erlang meta.function-call.erlang entity.name.function.erlang
+#                  ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.begin.erlang
+#                   ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                    ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.separator.parameters.erlang
+#                     ^ source.erlang meta.function.erlang meta.function-call.erlang constant.numeric.integer.decimal.erlang
+#                      ^ source.erlang meta.function.erlang meta.function-call.erlang punctuation.definition.parameters.end.erlang
+#                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+#                        ^ source.erlang meta.function.erlang
+#                         ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
 >    ok.
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang constant.other.symbol.unquoted.erlang
@@ -730,24 +870,64 @@
 #   ^ source.erlang meta.function.erlang
 #    ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
 #     ^ source.erlang meta.function.erlang keyword.operator.symbolic.erlang
+>    %% verbatim ('' == '~S' for triple-quoted strings)
+#^^^^ source.erlang meta.function.erlang punctuation.whitespace.comment.leading.erlang
+#    ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
+>    """
+#^^^^ source.erlang meta.function.erlang
+#    ^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
+>    monkey ~2..0b\n
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.triple.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.triple.erlang constant.character.format.placeholder.other.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.triple.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.triple.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#               ^^ source.erlang meta.function.erlang string.quoted.triple.erlang constant.character.format.placeholder.other.erlang
+#                 ^^^ source.erlang meta.function.erlang string.quoted.triple.erlang
+>    business
+#^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang
+>    """,
+#^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang
+#    ^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
+#       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>
+>    %% verbatim ('~' == '~B' for triple-quoted strings)
+#^^^^ source.erlang meta.function.erlang punctuation.whitespace.comment.leading.erlang
+#    ^ source.erlang meta.function.erlang comment.line.percentage.erlang punctuation.definition.comment.erlang
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang comment.line.percentage.erlang
 >    ~"""
 #^^^^ source.erlang meta.function.erlang
 #    ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
 #     ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >    monkey ~2..0b\n
-#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#               ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#                 ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    business
 #^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    """,
 #^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #    ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>
 >    ~b""""
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
 #      ^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >    monkey ~2..0b\n
-#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#               ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                  ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang
 >    """
 #^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    business
@@ -756,12 +936,19 @@
 #^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #    ^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #        ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>
 >    ~B"""""
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
 #      ^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >    monkey ~2..0b\n
-#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#               ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#                 ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    """
 #^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    business
@@ -770,12 +957,20 @@
 #^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #    ^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #         ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>
 >    ~s""""""
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
 #      ^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >    monkey ~2..0b\n
-#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#               ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#                 ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#                  ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang
 >    """
 #^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    business
@@ -784,12 +979,19 @@
 #^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #    ^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #          ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>
 >    ~S"""""""
 #^^^^ source.erlang meta.function.erlang
 #    ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
 #      ^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >    monkey ~2..0b\n
-#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.definition.placeholder.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#             ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#              ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang punctuation.separator.placeholder-parts.erlang
+#               ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.format.placeholder.other.erlang
+#                 ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    """
 #^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >    business
@@ -798,6 +1000,7 @@
 #^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #    ^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #           ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
+>
 >    X = lists:seq(1,3), % just to check is syntax highlight is still ok
 #^^^^ source.erlang meta.function.erlang
 #    ^ source.erlang meta.function.erlang variable.other.erlang
@@ -860,7 +1063,10 @@
 #        ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
 #          ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >          "\\µA"
-#^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang
+#             ^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >          """ = ~b'"\\µA"' =
 #^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #          ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
@@ -900,7 +1106,7 @@
 #         ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >          "\µA"
 #^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
->          """ = ~"\"\\µA\"" = ~/"\\µA"/
+>          """ = ~"\"\\µA\"" = ~/"\\µA"/,
 #^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #          ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #             ^ source.erlang meta.function.erlang
@@ -926,6 +1132,7 @@
 #                                  ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang constant.character.escape.erlang
 #                                   ^^^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang
 #                                      ^ source.erlang meta.function.erlang string.quoted.other.sigil.erlang punctuation.definition.string.end.erlang
+#                                       ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 >    X = lists:seq(1,3), % just to check is syntax highlight is still ok
 #^^^^ source.erlang meta.function.erlang
 #    ^ source.erlang meta.function.erlang variable.other.erlang
@@ -971,7 +1178,10 @@
 #        ^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
 #          ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >          "\\µA"
-#^^^^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#            ^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang
+#             ^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang
 >          """ = ~s"\"\\µA\"" = ~s["\\µA"] =
 #^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
 #          ^^^ source.erlang meta.function.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
@@ -1023,7 +1233,7 @@
 #        ^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >        "\µA"
 #^^^^^^^^^^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang
->        """ = "\"\\µA\""
+>        """ = "\"\\µA\"",
 #^^^^^^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang
 #        ^^^ source.erlang meta.function.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
 #           ^ source.erlang meta.function.erlang
@@ -1038,6 +1248,7 @@
 #                     ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
 #                      ^ source.erlang meta.function.erlang string.quoted.double.erlang constant.character.escape.erlang
 #                       ^ source.erlang meta.function.erlang string.quoted.double.erlang punctuation.definition.string.end.erlang
+#                        ^ source.erlang meta.function.erlang punctuation.separator.expressions.erlang
 >    X = lists:seq(1,3), % just to check is syntax highlight is still ok
 #^^^^ source.erlang meta.function.erlang
 #    ^ source.erlang meta.function.erlang variable.other.erlang


### PR DESCRIPTION
Set the syntax highlight to module and function documentation, more precisely to the docstring content of `-moduledoc` and `-doc` attributes to comment.

This change distinguish documentation comments and source code, just as the old EDoc comments did, and as other languages do as well, for example Elixir.

For more info, please check PR https://github.com/erlang-ls/grammar/pull/9.

An additional change also included in the branch of this PR, highlight `io:fread` and `io:fwrite` control sequences in verbatim strings for convenience.