### PR TITLE
Markdown comments

### DIFF
--- a/Erlang.plist
+++ b/Erlang.plist
@@ -605,7 +605,14 @@
 			<key>name</key>
 			<string>meta.directive.doc.erlang</string>
 			<key>contentName</key>
-			<string>comment.block.documentation.erlang</string>
+			<string>meta.embedded.block.markdown</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>text.html.markdown</string>
+				</dict>
+			</array>
 		</dict>
 		<key>docstring</key>
 		<dict>

--- a/Erlang.plist
+++ b/Erlang.plist
@@ -604,17 +604,8 @@
 			</dict>
 			<key>name</key>
 			<string>meta.directive.doc.erlang</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>\G</string>
-					<key>contentName</key>
-					<string>comment.block.documentation.erlang</string>
-					<key>while</key>
-					<string>(^)(?!\s*(\7))</string>
-				</dict>
-			</array>
+			<key>contentName</key>
+			<string>comment.block.documentation.erlang</string>
 		</dict>
 		<key>docstring</key>
 		<dict>

--- a/Erlang.plist
+++ b/Erlang.plist
@@ -612,7 +612,7 @@
 					<key>contentName</key>
 					<string>comment.block.documentation.erlang</string>
 					<key>while</key>
-					<string>(^)(?!\s*(\5))</string>
+					<string>(^)(?!\s*(\7))</string>
 				</dict>
 			</array>
 		</dict>

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ PowerShell) and all tests will be run. To add more tests you can either add
 annotated files to `./tests/` or use the snapshot facility and then tests should
 be added to `./test/snap`.
 
+To update the snapshot tests, simply:
+
+```
+npx vscode-tmgrammar-snap --updateSnapshot ./tests/snap/*.erl
+```
+
 See more:
 
 1. Visual Studio Code [Syntax Highlight Guide](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide)

--- a/README.md
+++ b/README.md
@@ -81,3 +81,4 @@ See more:
 2. TextMate [Language Grammars](https://macromates.com/manual/en/language_grammars)
 3. [Writing a TextMate Grammar: Some Lessons Learned](https://www.apeth.com/nonblog/stories/textmatebundle.html)
 4. [Building a syntax highlighting extension for VS Code](https://dev.to/borama/building-a-syntax-highlighting-extension-for-vs-code-594)
+5. [Regular expression editor](https://rubular.com/) to quickly experiment with matches and captures

--- a/tests/snap/docstring.erl.snap
+++ b/tests/snap/docstring.erl.snap
@@ -6,15 +6,15 @@
 #                 ^ source.erlang meta.directive.module.erlang punctuation.definition.parameters.end.erlang
 #                  ^ source.erlang meta.directive.module.erlang punctuation.section.directive.end.erlang
 >-moduledoc """
-#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
-# ^^^^^^^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
-#          ^ source.erlang meta.directive.doc.erlang
-#           ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^^^^^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#          ^ source.erlang meta.directive.erlang
+#           ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >Triple quoted strings examples
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang
 >""".
-#^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
-#   ^ source.erlang meta.directive.doc.erlang
+#^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
+#   ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
 >
 >-export([f1/0, f2/0, f3/0, f4/0, f5/0,
 #^ source.erlang meta.directive.export.erlang punctuation.section.directive.begin.erlang
@@ -79,16 +79,16 @@
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang comment.line.percentage.erlang
 >
 >-doc """
-#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
-# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
-#    ^ source.erlang meta.directive.doc.erlang
-#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang
+#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >     Docstring examples
-#^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang
 >     """.
-#^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
-#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
-#        ^ source.erlang meta.directive.doc.erlang
+#^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang
+#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
+#        ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
 >f1() ->
 #^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
 #  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
@@ -252,17 +252,19 @@
 #      ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
 >
 >-doc ~s"""""
-#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
-# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
-#    ^ source.erlang meta.directive.doc.erlang
-#     ^^ source.erlang meta.directive.doc.erlang storage.type.string.erlang
-#       ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang
+#     ^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
+#       ^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >      Hello\n
-#^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang
+#           ^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang punctuation.definition.escape.erlang
+#            ^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang constant.character.escape.erlang
 >      """"".
-#^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
-#      ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
-#           ^ source.erlang meta.directive.doc.erlang
+#^^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
+#      ^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
+#           ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
 >f2() -> ok.
 #^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
 #  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
@@ -347,17 +349,17 @@
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.erlang comment.line.percentage.erlang
 >
 >-doc("""
-#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
-# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
-#    ^ source.erlang meta.directive.doc.erlang punctuation.definition.parameters.begin.erlang
-#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang punctuation.definition.parameters.begin.erlang
+#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >     Hello\n
-#^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang
 >     """).
-#^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
-#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
-#        ^ source.erlang meta.directive.doc.erlang punctuation.section.directive.end.Erlang
-#         ^ source.erlang meta.directive.doc.erlang
+#^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang
+#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
+#        ^ source.erlang meta.directive.erlang punctuation.definition.parameters.end.erlang
+#         ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
 >g1() -> ok.
 #^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
 #  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang
@@ -370,18 +372,18 @@
 #          ^ source.erlang meta.function.erlang punctuation.terminator.function.erlang
 >
 >-doc(~B"""""
-#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
-# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
-#    ^ source.erlang meta.directive.doc.erlang punctuation.definition.parameters.begin.erlang
-#     ^^ source.erlang meta.directive.doc.erlang storage.type.string.erlang
-#       ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang punctuation.definition.parameters.begin.erlang
+#     ^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang storage.type.string.erlang
+#       ^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >      Hello\n
-#^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#^^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang
 >      """"").
-#^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
-#      ^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
-#           ^ source.erlang meta.directive.doc.erlang punctuation.section.directive.end.Erlang
-#            ^ source.erlang meta.directive.doc.erlang
+#^^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang
+#      ^^^^^ source.erlang meta.directive.erlang string.quoted.tripple.sigil.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
+#           ^ source.erlang meta.directive.erlang punctuation.definition.parameters.end.erlang
+#            ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
 >g2() -> ok.
 #^^ source.erlang meta.function.erlang entity.name.function.definition.erlang
 #  ^ source.erlang meta.function.erlang meta.expression.parenthesized punctuation.section.expression.begin.erlang

--- a/tests/snap/sigil.erl.snap
+++ b/tests/snap/sigil.erl.snap
@@ -24,16 +24,16 @@
 #                   ^ source.erlang meta.directive.export.erlang punctuation.section.directive.end.erlang
 >
 >-doc """
-#^ source.erlang meta.directive.doc.erlang punctuation.section.directive.begin.erlang
-# ^^^ source.erlang meta.directive.doc.erlang keyword.control.directive.doc.erlang
-#    ^ source.erlang meta.directive.doc.erlang
-#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.begin.erlang
+#^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
+# ^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang
+#    ^ source.erlang meta.directive.erlang
+#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.begin.erlang punctuation.definition.string.begin.erlang
 >     Sigil examples
-#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
+#^^^^^^^^^^^^^^^^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang
 >     """.
-#^^^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang
-#     ^^^ source.erlang meta.directive.doc.erlang comment.block.documentation.erlang punctuation.definition.string.end.erlang
-#        ^ source.erlang meta.directive.doc.erlang
+#^^^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang
+#     ^^^ source.erlang meta.directive.erlang string.quoted.triple.erlang meta.string.quoted.triple.end.erlang punctuation.definition.string.end.erlang
+#        ^ source.erlang meta.directive.erlang punctuation.section.directive.end.erlang
 >-spec f() -> ok.
 #^ source.erlang meta.directive.erlang punctuation.section.directive.begin.erlang
 # ^^^^ source.erlang meta.directive.erlang keyword.control.directive.erlang


### PR DESCRIPTION
# Overview

This is a proposal to enable syntax highlighting (and parentheses matching) for the content of Markdown doc attributes.

VS Code seems to allow [embedded languages](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#embedded-languages), and I think we'd gain a lot from having the ability of highlighing syntax for the markdown content

I am not super-familiar with TextMate grammars, so please advise if there's a better way.

This is what it looks like using the [ELP VS Code extension](https://marketplace.visualstudio.com/items?itemName=erlang-language-platform.erlang-language-platform):

<img width="863" alt="Screenshot 2025-05-23 at 12 48 51" src="https://github.com/user-attachments/assets/fcdfb1ac-9ca3-446f-bae1-14e791c58236" />

Compared to the current:

<img width="847" alt="Screenshot 2025-05-23 at 12 55 06" src="https://github.com/user-attachments/assets/26f04f79-b37a-4e60-99e9-7769ee0a743a" />

There's a gotcha. By default, the Markdown text looks like plain-text (e.g. white on dark themes), so to be able to see it as a comment, the extension can do something like:

```
"configurationDefaults": {
      "editor.tokenColorCustomizations": {
        "textMateRules": [
          {
            "scope": "meta.embedded.block.markdown",
            "settings": {
              "foreground": "#6A9955"
            }
          }
        ]
      }
    },
```

This is far from ideal, since each extension needs to add something similar. It can also play badly with custom themes, even if it's easily possible to override the font. Ideally, we'd like to tell VS Code to map that scope to whatever foreground is used for comments, but I could not find a way.

# Other changes included in this PR

These are superseded by the embedding of Markdown, but I think it's useful to share what I found while playing with this feature. Maybe there's something I'm missing.

## Incorrect grouping

The orginal match group (`\5`) seems incorrect to me. I believe it should have been `\7` (the closing quotes) as you can see [here](https://rubular.com/r/X4qN7mN1Gze1r2)

## Incorrect scopes

The original version did not fully work for me. While all the text was rendered as a comment, inspecting the scopes showed that odds/even lines had different scopes:

<img width="703" alt="Screenshot 2025-05-23 at 12 02 42" src="https://github.com/user-attachments/assets/ca78b52f-0ca8-4f6b-9bf6-8196e5219d98" />
<img width="612" alt="Screenshot 2025-05-23 at 12 02 49" src="https://github.com/user-attachments/assets/ee4d5ab0-eb0d-4311-a158-cea9a62cf325" />

In particular, odd lines had the `comment.block.documentation.erlang`, but even lines didn't.

